### PR TITLE
Moved sidebar to bottom + more responsiveness

### DIFF
--- a/assets/scripts/Origami.js
+++ b/assets/scripts/Origami.js
@@ -238,7 +238,7 @@ export class Origami {
   displayFortune(flapToOpen, fortune) {
   // Check which flap is open with switch statement, based on the flapToOpen parameter
   // It would change the css attribute of the content class in style.css.
-    const content = document.querySelector('.content');
+    const content = document.querySelector('.origamiFortuneOverlay');
     switch (flapToOpen) {
       case 1:
         content.style.left = '50%';

--- a/assets/scripts/SideBar.js
+++ b/assets/scripts/SideBar.js
@@ -32,27 +32,12 @@ export class SideBar {
    * @private
    */
   #generateButtons() {
-    this.textValues.forEach((text, index) => {
+    this.textValues.forEach((text) => {
       const button = document.createElement('button');
       button.textContent = text;
-      button.style.top = `${index*this.buttonHeight}px`;
     });
 
     this.buttons.push(button);
-  }
-
-  /**
-   * Appending buttons to a container
-   * @param {*} container - HTMLElement to append buttons to
-   */
-  appendAllButtonsToContainer(container) {
-    if (!(container instanceof HTMLElement)) {
-      throw new Error(`SideBar.appendAllButtonsToContainer requires HTMLElement, but was given: ${typeof(container)}!`);
-    }
-
-    this.buttons.forEach((button) => {
-      container.appendChild(button);
-    });
   }
 
   setButtonClickHandler(someFunction) {
@@ -111,7 +96,6 @@ function activateSidebarButtons() {
     const button = document.createElement('button');
     button.textContent = fortune;
 
-    button.style.top = `${index*buttonHeight}px`;
     button.addEventListener('click', () => {
       openFortuneInput(index);
       openSound.play();

--- a/assets/scripts/SideBar.js
+++ b/assets/scripts/SideBar.js
@@ -8,16 +8,14 @@ export class SideBar {
    * Represents a sidebar of buttons.
    * @constructor
    * @param {*} textArray - array of strings to be used as button text
-   * @param {*} buttonHeight - height of each button in pixels
    * @throws {Error} if textArray is empty
    */
-  constructor(textArray, buttonHeight=73) {
+  constructor(textArray) {
     if (textArray.length === 0) {
       throw new Error('Sidebar cannot be empty!');
     }
 
     this.buttons = [];
-    this.buttonHeight = buttonHeight;
     this.textValues = textArray.slice(0, this.MAX_BUTTONS);
 
     this.#init();
@@ -86,8 +84,6 @@ function activateSidebarHandler() {
     fortunes.
 */
 function activateSidebarButtons() {
-  const buttonHeight = 73;
-
   // using defaultFortunes is a convenient
   // placeholder pending externalizing fortune
   // values and modularizing defaults

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -146,6 +146,7 @@ object{
 /*container for Origami*/
 .container {
   position: relative;
+  pointer-events: none;
 }
 
 /*Fortune Overlay when Origami is in opened state */

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -50,6 +50,7 @@ object{
   z-index: 1;
   background: rgb(250, 231, 255);
   border: 1px solid #000000;
+  border-radius: 10px;
   cursor: pointer;
   animation: easeInFortunes 1s ease-in-out;
 }

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -7,13 +7,43 @@ object{
 	margin-left: auto;
 	margin-right: auto;
 	margin-top: 100px;
+
+  @media screen and (max-width: 850px) {
+    width: 400px;
+  }
+}
+
+.sidebar {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  height: calc(72px * 2 + 5);
+  max-width: 100%;
+
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  grid-template-rows: repeat(2, 1fr);
+  justify-content: center;
+  place-content: center;
+  grid-gap: 3px;
+  place-content: center;
+
+  @media screen and (max-width: 850px) {
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: repeat(4, 1fr);
+    height: calc(72px * 4 + 5);
+    transform: translate(-50%, -5%);
+  }
+    
 }
 
 /* Sidebar */
 .sidebar button {
   box-sizing: border-box;
+  position: relative;
 
-  position: absolute;
   width: 209px;
   height: 73px;
   left: 0px;
@@ -21,7 +51,7 @@ object{
   background: rgb(250, 231, 255);
   border: 1px solid #000000;
   cursor: pointer;
-  animation: slideInFromBottom 1s ease-in-out;
+  animation: easeInFortunes 1s ease-in-out;
 }
 
 .sidebar button:hover {
@@ -57,8 +87,9 @@ object{
   display: none;
   position: absolute;
   z-index: 1;
-  left: 500px;
-  top: 510px;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  bottom: 20vh;
 }
 
 .fortuneInputBox input {
@@ -69,6 +100,7 @@ object{
   border-radius: 10px;
   outline: none;
   box-shadow: none;
+  border: 1px solid #000000;
   transition: opacity 0.5s ease-in-out, max-height 0.5s ease-in-out;
 }
 
@@ -138,13 +170,11 @@ object{
   }
 }
 
-@keyframes slideInFromBottom {
+@keyframes easeInFortunes {
   0% {
-    transform: translateY(100%);
     opacity: 0;
   }
   100% {
-    transform: translateY(0);
     opacity: 1;
   }
 }

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -144,13 +144,18 @@ object{
   animation: slideInFromTop 1s ease-in-out;
 }
 /*container for Origami*/
-.container {
+.origamiContainer {
   position: relative;
   pointer-events: none;
 }
 
+/* all of its descendants */
+.origamiContainer * {
+  pointer-events: auto;
+}
+
 /*Fortune Overlay when Origami is in opened state */
-.content {
+.origamiFortuneOverlay {
   position: absolute;
   width: 100px;
   top: 125px;

--- a/index.html
+++ b/index.html
@@ -20,9 +20,10 @@
 			<input type="text" id="fortuneInput" class="text-input">
 			<button class ="saveButton">Save</button>
 		</div>
-    <div class="container">
+
+    <div class="origamiContainer">
       <object></object>
-      <div class="content">
+      <div class="origamiFortuneOverlay">
         <p></p>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Origami Fortune Teller</title>
     <link rel="icon" type="image/svg" href="favicon/favicon.svg" />
     <link rel="stylesheet" type="text/css" href="assets/styles/main.css" />


### PR DESCRIPTION
## Changes 
- Fortunes are now on the bottom of the screen. Normally there are 2 rows of 4 fortunes and when the screen becomes too small to fit them all (~850px), there are 4 rows of 2 fortunes.
- The custom fortune input box is now right above the fortunes and centered
- Some miscellaneous media queries to make things look better on smaller viewports
- Note: I accidentally merged these changes to main, so I reverted on main and set up this branch and pull request.

Closes #57 
Closes #72
<img width="1001" alt="Screenshot 2023-06-06 at 12 53 27 AM" src="https://github.com/cse110-sp23-group1/Origami-Fortune-Teller/assets/72187062/c5a97043-3f3e-44c8-b86d-85672233ac7f">
<img width="573" alt="Screenshot 2023-06-06 at 12 53 48 AM" src="https://github.com/cse110-sp23-group1/Origami-Fortune-Teller/assets/72187062/99754666-c69a-4b4d-8381-fe5a15d3311e">

