### PR TITLE
Merge code to support jsdocs deployment to separate repo

### DIFF
--- a/.github/workflows/jsdocs.yml
+++ b/.github/workflows/jsdocs.yml
@@ -27,4 +27,4 @@ jobs:
           folder: ./out
           repository-name: cse110-sp23-group1/origami-jsdocs
           branch: main
-          token: ${{ secrets.DEPLOY_KEY }}
+          token: ${{ secrets.JSDOCS_DEPLOY_KEY }}

--- a/.github/workflows/jsdocs.yml
+++ b/.github/workflows/jsdocs.yml
@@ -26,4 +26,5 @@ jobs:
         with:
           folder: ./out
           repository-name: cse110-sp23-group1/origami-jsdocs
+          branch: main
           token: ${{ secrets.DEPLOY_KEY }}

--- a/.github/workflows/jsdocs.yml
+++ b/.github/workflows/jsdocs.yml
@@ -25,4 +25,5 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: ./out
-          branch: gh-pages-docs
+          repository-name: cse110-sp23-group1/origami-jsdocs
+          token: ${{ secrets.DEPLOY_KEY }}


### PR DESCRIPTION
Workflow has been changed to support this, all that's needed is admin stuff to do @adarsh249, basic steps include get a personal access token from GitHub, then paste it as a repository secret in both the Origami-Fortune-Teller and origami-jsdocs repos and name it DEPLOY_KEY
